### PR TITLE
Allow specifying files to watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ hmr(callback, [options])
 * `options` Options object. Optional
   * `debug` Show list of modules which was removed from the cache. Default: false
   * `watchDir` Relative path to the directory to be watched recursively. Default: directory of the  current module
+  * `watchFilePatterns` Files that will trigger reload on change. Default: JS files
   * `chokidar` Chokidar [options](https://github.com/paulmillr/chokidar#api)
 
 ## Usage
@@ -56,7 +57,7 @@ let app;
 
 hmr(() => {
   app = require('../app');
-}, { watchDir: '../' });
+}, { watchDir: '../', watchFilePatterns: ['**/*.js'] });
 
 const server = http.createServer((req, res) => app(req, res));
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ class HMR {
   }
 
   setupWatcher() {
-    return chokidar.watch(['**/*.js'], {
+    return chokidar.watch(this.watchFilePatterns, {
       ignoreInitial: true,
       cwd: this.watchDir,
       ignored: [
@@ -55,6 +55,12 @@ class HMR {
   init(callback, options = {}) {
     this.callback = callback;
     this.options = options;
+
+    let watchFilePatterns = ["**/*.js"];
+    if (options.watchFilePatterns) {
+      watchFilePatterns = options.watchFilePatterns;
+    }
+    this.watchFilePatterns = watchFilePatterns;
 
     let watchDir = path.dirname(this.parentModuleName);
     if (options.watchDir) {


### PR DESCRIPTION
I got tripped up trying out this library with the assumption that all files in the watch directory would be monitored. Common examples may include `*.ts, *.jsx`, etc... so allow specifying as such.
Included the file watch pattern in the Readme to make it fairly explicit what the default is to avoid potential confusion.